### PR TITLE
Add test for InstanceSpec.<init> and .getQuorumPort

### DIFF
--- a/curator-test/src/test/java/org/apache/curator/test/TestTestingServer.java
+++ b/curator-test/src/test/java/org/apache/curator/test/TestTestingServer.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 
 import org.apache.zookeeper.server.ZooKeeperServer;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -49,5 +50,13 @@ public class TestTestingServer {
          zkTickTime = main.getZkServer().getTickTime();
       }
       assertEquals(customTickMs, zkTickTime);
+   }
+
+   @Test
+   public void testIsRunning() throws Exception {
+      final int defaultZkTickTime = ZooKeeperServer.DEFAULT_TICK_TIME;
+      final int customTickMs = defaultZkTickTime + (defaultZkTickTime == Integer.MAX_VALUE ? -1 : +1);
+      final InstanceSpec spec = new InstanceSpec(zkTmpDir, -1, -1, 2, true, -1, customTickMs, -1);
+      Assertions.assertEquals(2, spec.getQuorumPort());
    }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `spec.getQuorumPort()` is equal to `2`.
This tests the methods [`InstanceSpec.<init>`](https://github.com/apache/curator/blob/a5b24b8b5d954aea17fc0b1a50d23bb460482658/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java#L170) and [`InstanceSpec.getQuorumPort`](https://github.com/apache/curator/blob/a5b24b8b5d954aea17fc0b1a50d23bb460482658/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java#L204).
This test is based on the test [`setCustomTickTimeTest`](https://github.com/apache/curator/blob/a5b24b8b5d954aea17fc0b1a50d23bb460482658/curator-test/src/test/java/org/apache/curator/test/TestTestingServer.java#L37).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))